### PR TITLE
feat: 유저 정보와 유저의 주간 미션 정보 조회 기능 분리

### DIFF
--- a/src/main/java/gdsc/skhu/ourth/configure/SecurityConfig.java
+++ b/src/main/java/gdsc/skhu/ourth/configure/SecurityConfig.java
@@ -48,8 +48,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests()
                 .requestMatchers("/main", "/login", "/join", "/", "/logout", "/refresh").permitAll()
                 // 인증 완료 후 [USER] 또는 [ADMIN] 권한을 가진 사용자만 접근 허용
-                .requestMatchers("/user", "/usermission/add", "usermission/clear", "/rank/**", "/badge/**").hasRole("USER")
-                .requestMatchers("/mission", "/usermission", "/usermission/all").hasRole("ADMIN")
+                .requestMatchers("/user", "/mission", "/usermission/add", "usermission/clear", "/rank/**", "/badge/**").hasRole("USER")
+                .requestMatchers("/missions", "/usermission", "/usermission/all").hasRole("ADMIN")
                 // 이외에 모든 uri 요청은 인증을 완료해야 접근 허용
                 .anyRequest().authenticated()
 

--- a/src/main/java/gdsc/skhu/ourth/controller/MissionController.java
+++ b/src/main/java/gdsc/skhu/ourth/controller/MissionController.java
@@ -15,7 +15,7 @@ public class MissionController {
     private final MissionService missionService;
 
     // 미션 리스트 확인하기 - 관리자
-    @GetMapping("/mission")
+    @GetMapping("/missions")
     public List<MissionDTO.Response> missionList() {
         return missionService.missionList();
     }

--- a/src/main/java/gdsc/skhu/ourth/controller/UserController.java
+++ b/src/main/java/gdsc/skhu/ourth/controller/UserController.java
@@ -53,7 +53,7 @@ public class UserController {
 
     // 토큰 값으로 내 정보 확인 - 유저
     @GetMapping("/user")
-    public UserInfoDTO userInfo(Principal principal) {
+    public UserInfoDTO.userInfo userInfo(Principal principal) {
         return userService.userInfo(principal);
     }
 

--- a/src/main/java/gdsc/skhu/ourth/controller/UserMissionController.java
+++ b/src/main/java/gdsc/skhu/ourth/controller/UserMissionController.java
@@ -1,5 +1,6 @@
 package gdsc.skhu.ourth.controller;
 
+import gdsc.skhu.ourth.domain.dto.UserInfoDTO;
 import gdsc.skhu.ourth.domain.dto.UserMissionDTO;
 import gdsc.skhu.ourth.service.UserMissionService;
 import lombok.RequiredArgsConstructor;
@@ -7,12 +8,19 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 public class UserMissionController {
 
     private final UserMissionService userMissionService;
+
+    // 토큰 값으로 유저의 미션 리스트 확인 - 유저
+    @GetMapping("/mission")
+    public UserInfoDTO.missions missions(Principal principal) {
+        return userMissionService.findByUserMissions(principal);
+    }
 
     @PostMapping("/usermission/all")
     public ResponseEntity<String> addUserMissionAllUser() {

--- a/src/main/java/gdsc/skhu/ourth/domain/Badge.java
+++ b/src/main/java/gdsc/skhu/ourth/domain/Badge.java
@@ -26,4 +26,9 @@ public class Badge extends BaseTime {
                 .build();
     }
 
+    public BadgeDTO.RequestAddBadge toRequestAddDTO() {
+        return BadgeDTO.RequestAddBadge.builder()
+                .build();
+    }
+
 }

--- a/src/main/java/gdsc/skhu/ourth/domain/User.java
+++ b/src/main/java/gdsc/skhu/ourth/domain/User.java
@@ -52,13 +52,19 @@ public class User extends BaseTime implements UserDetails {
     @Builder.Default
     private List<String> roles = new ArrayList<>();
 
-    public UserInfoDTO toInfoDTO() {
-        return UserInfoDTO.builder()
+    public UserInfoDTO.userInfo toInfoDTO() {
+        return UserInfoDTO.userInfo.builder()
                 .id(id)
                 .email(email)
                 .username(username)
                 .school(school)
                 .point(point)
+                .build();
+    }
+
+    // 미션용
+    public UserInfoDTO.missions toUserInfoMissionDTO() {
+        return UserInfoDTO.missions.builder()
                 .userMissions(userMissions.stream()
                         .map(UserMission::toResponseDTO)
                         .collect(Collectors.toList()))

--- a/src/main/java/gdsc/skhu/ourth/domain/dto/UserInfoDTO.java
+++ b/src/main/java/gdsc/skhu/ourth/domain/dto/UserInfoDTO.java
@@ -2,32 +2,45 @@ package gdsc.skhu.ourth.domain.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import gdsc.skhu.ourth.domain.School;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.util.List;
 
-@Data
-@Builder
 public class UserInfoDTO {
 
-    // 유저의 정보를 전달하는 DTO
+    @Data
+    @Builder
+    public static class userInfo {  // 유저의 정보를 전달하는 DTO
 
-    private Long id;
+        private Long id;
 
-    private String email; // 유저 이메일
+        private String email; // 유저 이메일
 
-    private String username; // 유저 이름
+        private String username; // 유저 이름
 
-    @JsonIgnore
-    private School school; // 유저의 소속 학교
+        @JsonIgnore
+        private School school; // 유저의 소속 학교
 
-    private String schoolName; // 유저의 소속 학교 이름
+        private String schoolName; // 유저의 소속 학교 이름
 
-    private Long point; // 유저의 기여 포인트
+        private Long point; // 유저의 기여 포인트
 
-    private Boolean currentBadge; // 최근(이번 주) 획득한 뱃지 유무
+        private Boolean missionPresence; // 유저의 주간 미션 보유 여부
 
-    private List<UserMissionDTO.Response> userMissions; // 유저의 주간 미션 목록
+        private Integer missionCount; // 유저 미션이 있다면 몇 개 있는지
+
+    }
+
+    @Data
+    @Builder
+    @Getter
+    @Setter
+    public static class missions {
+
+        private Boolean currentBadge; // 최근(이번 주) 획득한 뱃지 유무
+
+        private List<UserMissionDTO.Response> userMissions; // 유저의 주간 미션 목록
+
+    }
 
 }

--- a/src/main/java/gdsc/skhu/ourth/repository/BadgeRepository.java
+++ b/src/main/java/gdsc/skhu/ourth/repository/BadgeRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface BadgeRepository extends JpaRepository<Badge, Long> {
 
@@ -13,6 +14,7 @@ public interface BadgeRepository extends JpaRepository<Badge, Long> {
     List<Badge> findByUser(User user);
 
     // 해당 기간 사이의 획득한 뱃지 목록
-    List<Badge> findByCreateDateBetweenAndUser(LocalDateTime start, LocalDateTime end, User user);
+
+    Optional<Badge> findByCreateDateBetweenAndUser(LocalDateTime start, LocalDateTime end, User user);
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
       port: 6379
 jwt:
   secret: Z2RzYy1za2h1LWphdmEtYmFja2VuZC1qd3Qtc3R1ZHktZGVjZW1iZXItMjh0aC1oYW5naWxsZWU=
-  access-token-validity-in-milliseconds: 1800000 #1800000
+  access-token-validity-in-milliseconds: 1800000
   refresh-token-validity-in-milliseconds: 1209600000
 server:
   port: 8443

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
       port: 6379
 jwt:
   secret: Z2RzYy1za2h1LWphdmEtYmFja2VuZC1qd3Qtc3R1ZHktZGVjZW1iZXItMjh0aC1oYW5naWxsZWU=
-  access-token-validity-in-milliseconds: 60000 #1800000
+  access-token-validity-in-milliseconds: 1800000 #1800000
   refresh-token-validity-in-milliseconds: 1209600000
 server:
   port: 8443


### PR DESCRIPTION
기존 유저 정보와 미션 정보를 한 번에 조회하게 되어있었지만
로딩 시간이 길어지는 문제 발생

-> 각 페이지에 필요한 정보만 보내도록 기능 별로 api를 분리